### PR TITLE
Added support for arrays at the root

### DIFF
--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -68,7 +68,7 @@ func CreatePatch(a, b []byte) ([]Operation, error) {
 	if err != nil {
 		return nil, errBadJSONDoc
 	}
-	return handleValues(aI, bI, "", []JsonPatchOperation{})
+	return handleValues(aI, bI, "", []Operation{})
 }
 
 // Returns true if the values matches (must be json types)

--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -58,8 +58,8 @@ func NewPatch(operation, path string, value interface{}) Operation {
 //
 // An error will be returned if any of the two documents are invalid.
 func CreatePatch(a, b []byte) ([]Operation, error) {
-	aI := map[string]interface{}{}
-	bI := map[string]interface{}{}
+	var aI interface{}
+	var bI interface{}
 	err := json.Unmarshal(a, &aI)
 	if err != nil {
 		return nil, errBadJSONDoc
@@ -68,7 +68,7 @@ func CreatePatch(a, b []byte) ([]Operation, error) {
 	if err != nil {
 		return nil, errBadJSONDoc
 	}
-	return diff(aI, bI, "", []Operation{})
+	return handleValues(aI, bI, "", []JsonPatchOperation{})
 }
 
 // Returns true if the values matches (must be json types)

--- a/jsonpatch_test.go
+++ b/jsonpatch_test.go
@@ -704,7 +704,6 @@ var (
 }`
 )
 
-
 var (
 	oldNestedObj = `{
   "apiVersion": "kubedb.com/v1alpha1",
@@ -737,7 +736,6 @@ var (
   }
 }`
 )
-
 
 func TestCreatePatch(t *testing.T) {
 	cases := []struct {
@@ -779,7 +777,10 @@ func TestCreatePatch(t *testing.T) {
 		{"Kubernetes:Annotations", oldDeployment, newDeployment},
 		// crd with nested object
 		{"Nested Member Object", oldNestedObj, newNestedObj},
+		{"Array at root", `[{"asdf":"qwerty"}]`, `[{"asdf":"bla"},{"asdf":"zzz"}]`},
+		{"Empty array at root", `[]`, `[{"asdf":"bla"},{"asdf":"zzz"}]`},
 	}
+
 	for _, c := range cases {
 		t.Run(c.name+"[src->dst]", func(t *testing.T) {
 			check(t, c.src, c.dst)


### PR DESCRIPTION
Currently it is possible to create json patches for arrays if they are nested inside an object, but not if they are at the root of the json, e.g. currently it's not possible to generate a json patch for:
```
[{"asdf":"qwerty"}] -> [{"asdf":"bla"},{"qwerty":"zzz"}]
```