### PR TITLE
[Emergency] correct array index in backtrace

### DIFF
--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -326,7 +326,7 @@ func backtrace(s, t []interface{}, p string, i int, j int, matrix [][]int) []Ope
 			return append([]Operation{op}, backtrace(s, t, p, i-1, j-1, matrix)...)
 		}
 
-		p2, _ := handleValues(s[j-1], t[j-1], makePath(p, i-1), []Operation{})
+		p2, _ := handleValues(s[i-1], t[j-1], makePath(p, i-1), []Operation{})
 		return append(p2, backtrace(s, t, p, i-1, j-1, matrix)...)
 	}
 	if i > 0 && j > 0 && matrix[i-1][j-1] == matrix[i][j] {

--- a/jsonpatch_test.go
+++ b/jsonpatch_test.go
@@ -704,7 +704,6 @@ var (
 }`
 )
 
-
 var (
 	oldNestedObj = `{
   "apiVersion": "kubedb.com/v1alpha1",
@@ -738,6 +737,69 @@ var (
 }`
 )
 
+var (
+	oldArray = `{
+  "apiVersion": "kubedb.com/v1alpha1",
+  "kind": "Elasticsearch",
+  "metadata": {
+    "name": "quick-elasticsearch",
+    "namespace": "demo"
+  },
+  "spec": {
+    "tolerations": [
+      {
+          "key": "node.kubernetes.io/key1",
+          "operator": "Equal",
+          "value": "value1",
+          "effect": "NoSchedule"
+      },
+      {
+          "key": "node.kubernetes.io/key2",
+          "operator": "Equal",
+          "value": "value2",
+          "effect": "NoSchedule"
+      },
+      {
+          "key": "node.kubernetes.io/not-ready",
+          "operator": "Exists",
+          "effect": "NoExecute",
+          "tolerationSeconds": 300
+      },
+      {
+          "key": "node.kubernetes.io/unreachable",
+          "operator": "Exists",
+          "effect": "NoExecute",
+          "tolerationSeconds": 300
+      }
+    ]
+  }
+}`
+
+	newArray = `{
+  "apiVersion": "kubedb.com/v1alpha1",
+  "kind": "Elasticsearch",
+  "metadata": {
+    "name": "quick-elasticsearch",
+    "namespace": "demo"
+  },
+  "spec": {
+    "tolerations": [
+      {
+          "key": "node.kubernetes.io/key2",
+          "operator": "Equal",
+          "value": "value2",
+          "effect": "NoSchedule"
+      },
+      {
+          "key": "node.kubernetes.io/key1",
+          "operator": "Equal",
+          "value": "value1",
+          "effect": "NoSchedule"
+      }
+    ]
+  }
+}`
+)
 
 func TestCreatePatch(t *testing.T) {
 	cases := []struct {
@@ -779,6 +841,8 @@ func TestCreatePatch(t *testing.T) {
 		{"Kubernetes:Annotations", oldDeployment, newDeployment},
 		// crd with nested object
 		{"Nested Member Object", oldNestedObj, newNestedObj},
+		// array with different order
+		{"Different Array", oldArray, newArray},
 	}
 	for _, c := range cases {
 		t.Run(c.name+"[src->dst]", func(t *testing.T) {


### PR DESCRIPTION
This bug causes wrong patches in `kubernetes-sig/controller-runtime`.