### PR TITLE
Shortcut when two json documents are same

### DIFF
--- a/v2/bench_test.go
+++ b/v2/bench_test.go
@@ -19,8 +19,8 @@ func BenchmarkCreatePatch(b *testing.B) {
 		},
 		{
 			"large array",
-			largeArray(1000),
-			largeArray(1000),
+			largeArray(1000, "a"),
+			largeArray(1000, "b"),
 		},
 		{
 			"simple",
@@ -40,7 +40,7 @@ func BenchmarkCreatePatch(b *testing.B) {
 	}
 }
 
-func largeArray(size int) string {
+func largeArray(size int, val string) string {
 	type nested struct {
 		A, B string
 	}
@@ -49,7 +49,7 @@ func largeArray(size int) string {
 	}
 	a := example{}
 	for i := 0; i < size; i++ {
-		a.Objects = append(a.Objects, nested{A: "a", B: "b"})
+		a.Objects = append(a.Objects, nested{A: "a", B: val})
 	}
 	res, _ := json.Marshal(a)
 	return string(res)

--- a/v2/jsonpatch.go
+++ b/v2/jsonpatch.go
@@ -64,6 +64,9 @@ func NewOperation(op, path string, value interface{}) Operation {
 //
 // An error will be returned if any of the two documents are invalid.
 func CreatePatch(a, b []byte) ([]Operation, error) {
+	if reflect.DeepEqual(a, b) {
+		return []Operation{}, nil
+	}
 	var aI interface{}
 	var bI interface{}
 	err := json.Unmarshal(a, &aI)

--- a/v2/jsonpatch.go
+++ b/v2/jsonpatch.go
@@ -1,6 +1,7 @@
 package jsonpatch
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -64,7 +65,7 @@ func NewOperation(op, path string, value interface{}) Operation {
 //
 // An error will be returned if any of the two documents are invalid.
 func CreatePatch(a, b []byte) ([]Operation, error) {
-	if reflect.DeepEqual(a, b) {
+	if bytes.Equal(a, b) {
 		return []Operation{}, nil
 	}
 	var aI interface{}


### PR DESCRIPTION
When two json documents are same, patch is not created.
However, current code tries to check the diff and takes some time and memory.
Hence this patch adds `bytes.Equal` before creating patch to skip it.

Also, the current bench mark `largeArray` is using a same value
so update it to use different values in array.

Here is the bench mark before(13a9e4aa3fb1cfaa214b721a784aaa51e12641f8) and after (d5e56020aa6ae1345bdc46899f76a820e472a7f1). 
* `large_array` becomes much faster.
* `reflect.DeepEqual` does not make much performance degradation as per `complex` and `simple` tests.

```
goos: linux
goarch: amd64
pkg: gomodules.xyz/jsonpatch/v2
cpu: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
                          │     before      │                after                 │
                          │     sec/op      │    sec/op     vs base                │
CreatePatch/complex-8          152.5µ ± 22%   150.4µ ±  4%        ~ (p=0.796 n=10)
CreatePatch/large_array-8   1479.550µ ± 26%   8.061µ ± 28%  -99.46% (p=0.000 n=10)
CreatePatch/simple-8           19.30µ ± 25%   14.77µ ± 10%  -23.46% (p=0.023 n=10)
geomean                        163.3µ         26.16µ        -83.98%

                          │    before     │                after                 │
                          │     B/op      │     B/op      vs base                │
CreatePatch/complex-8        83.80Ki ± 0%   83.83Ki ± 0%   +0.04% (p=0.013 n=10)
CreatePatch/large_array-8   945.37Ki ± 0%   36.05Ki ± 0%  -96.19% (p=0.000 n=10)
CreatePatch/simple-8         2.289Ki ± 9%   2.539Ki ± 8%  +10.92% (p=0.005 n=10)
geomean                      56.60Ki        19.72Ki       -65.15%

                          │     before     │                after                │
                          │   allocs/op    │  allocs/op   vs base                │
CreatePatch/complex-8          1.180k ± 0%   1.182k ± 0%   +0.17% (p=0.001 n=10)
CreatePatch/large_array-8   14785.000 ± 0%    4.000 ± 0%  -99.97% (p=0.000 n=10)
CreatePatch/simple-8            33.00 ± 6%    37.00 ± 5%  +12.12% (p=0.001 n=10)
geomean                         831.9         55.93       -93.28%
```