### PR TITLE
Fix: handle lossy max int64

### DIFF
--- a/v2/jsonpatch.go
+++ b/v2/jsonpatch.go
@@ -70,12 +70,14 @@ func CreatePatch(a, b []byte) ([]Operation, error) {
 	}
 	var aI interface{}
 	var bI interface{}
-	err := json.Unmarshal(a, &aI)
-	if err != nil {
+	aDec := json.NewDecoder(bytes.NewReader(a))
+	aDec.UseNumber()
+	if err := aDec.Decode(&aI); err != nil {
 		return nil, errBadJSONDoc
 	}
-	err = json.Unmarshal(b, &bI)
-	if err != nil {
+	bDec := json.NewDecoder(bytes.NewReader(b))
+	bDec.UseNumber()
+	if err := bDec.Decode(&bI); err != nil {
 		return nil, errBadJSONDoc
 	}
 	return handleValues(aI, bI, "", []Operation{})
@@ -91,6 +93,11 @@ func matchesValue(av, bv interface{}) bool {
 	switch at := av.(type) {
 	case string:
 		bt, ok := bv.(string)
+		if ok && bt == at {
+			return true
+		}
+	case json.Number:
+		bt, ok := bv.(json.Number)
 		if ok && bt == at {
 			return true
 		}
@@ -212,7 +219,7 @@ func handleValues(av, bv interface{}, p string, patch []Operation) ([]Operation,
 		if err != nil {
 			return nil, err
 		}
-	case string, float64, bool:
+	case string, float64, bool, json.Number:
 		if !matchesValue(av, bv) {
 			patch = append(patch, NewOperation("replace", p, bv))
 		}

--- a/v2/jsonpatch_test.go
+++ b/v2/jsonpatch_test.go
@@ -16,6 +16,7 @@ var simpleD = `{"a":100, "b":200, "c":"hello", "d":"foo"}`
 var simpleE = `{"a":100, "b":200}`
 var simplef = `{"a":100, "b":100, "d":"foo"}`
 var simpleG = `{"a":100, "b":null, "d":"foo"}`
+var simpleH = `{"a":100, "b":200, "c":"hello", "d": 9223372036854775500}`
 var empty = `{}`
 
 var arraySrc = `
@@ -859,6 +860,7 @@ func TestCreatePatch(t *testing.T) {
 		{"Simple:OneAdd", simpleA, simpleD},
 		{"Simple:OneRemove", simpleA, simpleE},
 		{"Simple:VsEmpty", simpleA, empty},
+		{"Simple:AddBigInt", simpleA, simpleH},
 		// array types
 		{"Array:Same", arraySrc, arraySrc},
 		{"Array:BoolReplace", arraySrc, arrayDst},


### PR DESCRIPTION
#39 

Use the json Decoder with the `json.Number` type to handle max int64 values as int64 instead of float64 with scientific format. 