### PR TITLE
Remove indirect dependency on github.com/pkg/errors

### DIFF
--- a/v2/fuzz_test.go
+++ b/v2/fuzz_test.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	jp "github.com/evanphx/json-patch"
 	"github.com/stretchr/testify/assert"
 	"gomodules.xyz/jsonpatch/v2"
+	jp "gopkg.in/evanphx/json-patch.v4"
 )
 
 func FuzzCreatePatch(f *testing.F) {

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,12 +3,11 @@ module gomodules.xyz/jsonpatch/v2
 go 1.20
 
 require (
-	github.com/evanphx/json-patch v0.5.2
 	github.com/stretchr/testify v1.3.0
+	gopkg.in/evanphx/json-patch.v4 v4.13.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,12 +1,9 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8P3k=
-github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
-github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnfEbYzo=
+gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=

--- a/v2/jsonpatch_test.go
+++ b/v2/jsonpatch_test.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	jp "github.com/evanphx/json-patch"
 	"github.com/stretchr/testify/assert"
 	"gomodules.xyz/jsonpatch/v2"
+	jp "gopkg.in/evanphx/json-patch.v4"
 )
 
 var simpleA = `{"a":100, "b":200, "c":"hello"}`


### PR DESCRIPTION
The `github.com/pkg/errors` package has been archived for some time.

```diff
--- go mod graph # release-2.0
+++ go mod graph # pr-42
@@ -1,11 +1,8 @@
 gomodules.xyz/jsonpatch/v2 github.com/davecgh/go-spew@v1.1.0
-gomodules.xyz/jsonpatch/v2 github.com/evanphx/json-patch@v0.5.2
-gomodules.xyz/jsonpatch/v2 github.com/pkg/errors@v0.9.1
 gomodules.xyz/jsonpatch/v2 github.com/pmezard/go-difflib@v1.0.0
 gomodules.xyz/jsonpatch/v2 github.com/stretchr/testify@v1.3.0
 gomodules.xyz/jsonpatch/v2 go@1.20
-github.com/evanphx/json-patch@v0.5.2 github.com/jessevdk/go-flags@v1.4.0
-github.com/evanphx/json-patch@v0.5.2 github.com/pkg/errors@v0.9.1
+gomodules.xyz/jsonpatch/v2 gopkg.in/evanphx/json-patch.v4@v4.13.0
 github.com/stretchr/testify@v1.3.0 github.com/davecgh/go-spew@v1.1.0
 github.com/stretchr/testify@v1.3.0 github.com/pmezard/go-difflib@v1.0.0
 github.com/stretchr/testify@v1.3.0 github.com/stretchr/objx@v0.1.0

```